### PR TITLE
Added Japanese support for getting string length.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     },
     "require": {
         "php": ">=7.3",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.0",

--- a/src/Inputs/HasPlaceholder.php
+++ b/src/Inputs/HasPlaceholder.php
@@ -29,7 +29,9 @@ trait HasPlaceholder
      */
     public function placeholder(string $placeholder): self
     {
-        if (strlen($placeholder) > 150) {
+        /** @var string */
+        $encoding = mb_detect_encoding($placeholder);
+        if (mb_strlen($placeholder, $encoding) > 150) {
             throw new Exception('Placeholder cannot exceed 150 characters');
         }
 

--- a/src/Inputs/HasPlaceholder.php
+++ b/src/Inputs/HasPlaceholder.php
@@ -29,9 +29,7 @@ trait HasPlaceholder
      */
     public function placeholder(string $placeholder): self
     {
-        /** @var string */
-        $encoding = mb_detect_encoding($placeholder);
-        if (mb_strlen($placeholder, $encoding) > 150) {
+        if (mb_strlen($placeholder, 'UTF-8') > 150) {
             throw new Exception('Placeholder cannot exceed 150 characters');
         }
 

--- a/src/Partials/Text.php
+++ b/src/Partials/Text.php
@@ -47,18 +47,15 @@ abstract class Text extends Element
      */
     public static function validateString(?string $text, ?int $max = null, int $min = 1): void
     {
-        /** @var string */
-        $encoding = mb_detect_encoding($text);
-
         if (!is_string($text)) {
             throw new Exception('Text element must have a "text" value');
         }
 
-        if (mb_strlen($text, $encoding) < $min) {
+        if (mb_strlen($text, 'UTF-8') < $min) {
             throw new Exception('Text element must have a "text" value with a length of at least %d', [$min]);
         }
 
-        if (is_int($max) && mb_strlen($text, $encoding) > $max) {
+        if (is_int($max) && mb_strlen($text, 'UTF-8') > $max) {
             throw new Exception('Text element must have a "text" value with a length of at most %d', [$max]);
         }
     }

--- a/src/Partials/Text.php
+++ b/src/Partials/Text.php
@@ -47,15 +47,18 @@ abstract class Text extends Element
      */
     public static function validateString(?string $text, ?int $max = null, int $min = 1): void
     {
+        /** @var string */
+        $encoding = mb_detect_encoding($text);
+
         if (!is_string($text)) {
             throw new Exception('Text element must have a "text" value');
         }
 
-        if (strlen($text) < $min) {
+        if (mb_strlen($text, $encoding) < $min) {
             throw new Exception('Text element must have a "text" value with a length of at least %d', [$min]);
         }
 
-        if (is_int($max) && strlen($text) > $max) {
+        if (is_int($max) && mb_strlen($text, $encoding) > $max) {
             throw new Exception('Text element must have a "text" value with a length of at most %d', [$max]);
         }
     }

--- a/tests/Partials/TextTest.php
+++ b/tests/Partials/TextTest.php
@@ -18,7 +18,8 @@ class TextTest extends TestCase
 
     public function testCanValidateEnglishText()
     {
-        $text = new class() extends Text{};
+        $text = new class () extends Text {
+        };
 
         $text->validateString('abc', self::MAX_LENGTH);
 
@@ -33,7 +34,8 @@ class TextTest extends TestCase
 
     public function testCanValidateJapaneseText()
     {
-        $text = new class() extends Text{};
+        $text = new class () extends Text {
+        };
 
         $text->validateString('いろは', self::MAX_LENGTH);
 

--- a/tests/Partials/TextTest.php
+++ b/tests/Partials/TextTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Partials;
+
+use SlackPhp\BlockKit\Exception;
+use SlackPhp\BlockKit\Partials\Text;
+use SlackPhp\BlockKit\Tests\TestCase;
+
+/**
+ * @covers \SlackPhp\BlockKit\Partials\Text
+ */
+class TextTest extends TestCase
+{
+    private const MAX_LENGTH = 5;
+    private const MIN_LENGTH = 2;
+
+    public function testCanValidateEnglishText()
+    {
+        $text = new class() extends Text{};
+
+        $text->validateString('abc', self::MAX_LENGTH);
+
+        $this->expectException(Exception::class);
+
+        $this->expectExceptionMessage('Text element must have a "text" value with a length of at most 5');
+        $text->validateString('abcdefg', self::MAX_LENGTH);
+
+        $this->expectExceptionMessage('Text element must have a "text" value with a length of at least 2');
+        $text->validateString('a', self::MAX_LENGTH, self::MIN_LENGTH);
+    }
+
+    public function testCanValidateJapaneseText()
+    {
+        $text = new class() extends Text{};
+
+        $text->validateString('いろは', self::MAX_LENGTH);
+
+        $this->expectException(Exception::class);
+
+        $this->expectExceptionMessage('Text element must have a "text" value with a length of at most 5');
+        $text->validateString('いろはにほへと', self::MAX_LENGTH);
+
+        $this->expectExceptionMessage('Text element must have a "text" value with a length of at least 2');
+        $text->validateString('い', self::MAX_LENGTH, self::MIN_LENGTH);
+    }
+}


### PR DESCRIPTION
# TL;DR
Fixed using` mb_strlen()` to get the string length instead of strlen().

# Details
* For elements such as placeholder and tittle, where the number of characters that can be entered is limited, the specification is to get the number of characters and throw an exception if it exceeds the limit.
* The `strlen()` method is used to get the length of a string.
* For strings consisting of only alphabetic characters (e.g. ASCII encoding), the strlen() method will give correct results, but for strings containing Japanese or other characters (e.g. UTF-8 encoding), it may not give correct results.
* This is because the `strlen()` method is designed to return the number of bytes, not the number of characters, and the number of characters and the number of bytes match for encodings with 1 byte per character, such as alphabetic characters, but not for encodings with around 3 bytes per character, such as Japanese (UTF-8).
* In this fix, `mb_strlen()`, which supports multibyte characters, is used so that even Japanese string lengths can be obtained correctly.

Thanx.