### PR TITLE
Added duplicate validation for block_id and action_id

### DIFF
--- a/src/Blocks/Actions.php
+++ b/src/Blocks/Actions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SlackPhp\BlockKit\Blocks;
 
 use SlackPhp\BlockKit\{Element, Exception, HydrationData, Inputs, Type};
+use SlackPhp\BlockKit\Inputs\InputElement;
 
 class Actions extends BlockElement
 {
@@ -108,8 +109,26 @@ class Actions extends BlockElement
             throw new Exception('Context must contain at least one element');
         }
 
+        $actionIds = [];
         foreach ($this->elements as $element) {
             $element->validate();
+            if ($element instanceof InputElement && ! is_null($element->getActionId())) {
+                $actionIds[] = $element->getActionId();
+            }
+        }
+
+        $actionIdArrayCount = array_count_values($actionIds);
+        if (count($actionIdArrayCount) > 0) {
+            $duplicateActionIds = [];
+            foreach ($actionIdArrayCount as $key => $value) {
+                if ((int)$value > 1) {
+                    $duplicateActionIds[] = $key;
+                }
+            }
+
+            if (count($duplicateActionIds) > 0) {
+                throw new Exception('The following action_ids are duplicated : ' . implode(', ', $duplicateActionIds) . ' ]');
+            }
         }
     }
 

--- a/src/Blocks/Actions.php
+++ b/src/Blocks/Actions.php
@@ -127,7 +127,9 @@ class Actions extends BlockElement
             }
 
             if (count($duplicateActionIds) > 0) {
-                throw new Exception('The following action_ids are duplicated : ' . implode(', ', $duplicateActionIds) . ' ]');
+                throw new Exception(
+                    'The following action_ids are duplicated : ' . implode(', ', $duplicateActionIds) . ' ]'
+                );
             }
         }
     }

--- a/src/Inputs/InputElement.php
+++ b/src/Inputs/InputElement.php
@@ -34,6 +34,14 @@ abstract class InputElement extends Element
     }
 
     /**
+     * @return string|null
+     */
+    public function getActionId(): ?string
+    {
+        return $this->actionId;
+    }
+
+    /**
      * @return array
      */
     public function toArray(): array

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -216,7 +216,9 @@ abstract class Surface extends Element
             }
 
             if (count($duplicateBlockIds) > 0) {
-                throw new Exception('The following block_ids are duplicated : ' . implode(', ', $duplicateBlockIds) . ' ]');
+                throw new Exception(
+                    'The following block_ids are duplicated : ' . implode(', ', $duplicateBlockIds) . ' ]'
+                );
             }
         }
     }

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -216,7 +216,7 @@ abstract class Surface extends Element
             }
 
             if (count($duplicateBlockIds) > 0) {
-                throw new Exception('The following IDs are duplicated : ' . implode(', ', $duplicateBlockIds) . ' ]');
+                throw new Exception('The following block_ids are duplicated : ' . implode(', ', $duplicateBlockIds) . ' ]');
             }
         }
     }

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -198,8 +198,26 @@ abstract class Surface extends Element
             throw new Exception('A surface cannot have more than %d blocks', [self::MAX_BLOCKS]);
         }
 
+        $blolckIds = [];
         foreach ($blocks as $block) {
             $block->validate();
+            if (! is_null($block->getBlockId())) {
+                $blolckIds[] = $block->getBlockId();
+            }
+        }
+
+        $blockIdArrayCount = array_count_values($blolckIds);
+        if (count($blockIdArrayCount) > 0) {
+            $duplicateBlockIds = [];
+            foreach ($blockIdArrayCount as $key => $value) {
+                if ((int)$value > 1) {
+                    $duplicateBlockIds[] = $key;
+                }
+            }
+
+            if (count($duplicateBlockIds) > 0) {
+                throw new Exception('The following IDs are duplicated : ' . implode(', ', $duplicateBlockIds) . ' ]');
+            }
         }
     }
 

--- a/tests/Blocks/ActionsTest.php
+++ b/tests/Blocks/ActionsTest.php
@@ -17,7 +17,9 @@ class ActionsTest extends TestCase
     public function testCanValidateDupilcateActionId(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Slack Block Kit Error: The following action_ids are duplicated : test-action-1, test-action-3 ]');
+        $this->expectExceptionMessage(
+            'Slack Block Kit Error: The following action_ids are duplicated : test-action-1, test-action-3 ]'
+        );
 
         $surface = $this->getMockSurface()
             ->add(

--- a/tests/Blocks/ActionsTest.php
+++ b/tests/Blocks/ActionsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Blocks;
+
+use SlackPhp\BlockKit\Blocks\Actions;
+use SlackPhp\BlockKit\Tests\TestCase;
+use SlackPhp\BlockKit\Exception;
+use SlackPhp\BlockKit\Inputs\Button;
+
+/**
+ * @covers \SlackPhp\BlockKit\Blocks\Actions
+ */
+class ActionsTest extends TestCase
+{
+    public function testCanValidateDupilcateActionId(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Slack Block Kit Error: The following action_ids are duplicated : test-action-1, test-action-3 ]');
+
+        $surface = $this->getMockSurface()
+            ->add(
+                Actions::new()
+                ->add(
+                    Button::new()
+                    ->actionId('test-action-1')
+                    ->text('Submit')
+                    ->value('Hi!')
+                )
+                ->add(
+                    Button::new()
+                    ->actionId('test-action-1')
+                    ->text('Submit')
+                    ->value('Hi!')
+                )
+                ->add(
+                    Button::new()
+                    ->actionId('test-action-2')
+                    ->text('Submit')
+                    ->value('Hi!')
+                )
+                ->add(
+                    Button::new()
+                    ->actionId('test-action-3')
+                    ->text('Submit')
+                    ->value('Hi!')
+                )
+                ->add(
+                    Button::new()
+                    ->actionId('test-action-3')
+                    ->text('Submit')
+                    ->value('Hi!')
+                )
+            )
+            ->toArray();
+    }
+}

--- a/tests/Surfaces/SurfaceTest.php
+++ b/tests/Surfaces/SurfaceTest.php
@@ -75,7 +75,7 @@ class SurfaceTest extends TestCase
     public function testCanValidateDupilcateBlockId(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Slack Block Kit Error: The following IDs are duplicated : test-block-1, test-block-3 ]');
+        $this->expectExceptionMessage('Slack Block Kit Error: The following block_ids are duplicated : test-block-1, test-block-3 ]');
 
         $surface = $this->getMockSurface()
             ->add(

--- a/tests/Surfaces/SurfaceTest.php
+++ b/tests/Surfaces/SurfaceTest.php
@@ -6,6 +6,8 @@ namespace SlackPhp\BlockKit\Tests\Surfaces;
 
 use SlackPhp\BlockKit\Blocks\Section;
 use SlackPhp\BlockKit\Blocks\Virtual\TwoColumnTable;
+use SlackPhp\BlockKit\Exception;
+use SlackPhp\BlockKit\Kit;
 use SlackPhp\BlockKit\Tests\TestCase;
 
 /**
@@ -72,6 +74,35 @@ class SurfaceTest extends TestCase
 
     public function testCanValidateDupilcateBlockId(): void
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Slack Block Kit Error: The following IDs are duplicated : test-block-1, test-block-3 ]');
 
+        $surface = $this->getMockSurface()
+            ->add(
+                Section::new()
+                    ->blockId('test-block-1')
+                    ->plainText('test plain text.')
+            )
+            ->add(
+                Section::new()
+                    ->blockId('test-block-1')
+                    ->plainText('test plain text.')
+            )
+            ->add(
+                Section::new()
+                    ->blockId('test-block-2')
+                    ->plainText('test plain text.')
+            )
+            ->add(
+                Section::new()
+                    ->blockId('test-block-3')
+                    ->plainText('test plain text.')
+            )
+            ->add(
+                Section::new()
+                    ->blockId('test-block-3')
+                    ->plainText('test plain text.')
+            )
+            ->toArray();
     }
 }

--- a/tests/Surfaces/SurfaceTest.php
+++ b/tests/Surfaces/SurfaceTest.php
@@ -75,7 +75,9 @@ class SurfaceTest extends TestCase
     public function testCanValidateDupilcateBlockId(): void
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Slack Block Kit Error: The following block_ids are duplicated : test-block-1, test-block-3 ]');
+        $this->expectExceptionMessage(
+            'Slack Block Kit Error: The following block_ids are duplicated : test-block-1, test-block-3 ]'
+        );
 
         $surface = $this->getMockSurface()
             ->add(

--- a/tests/Surfaces/SurfaceTest.php
+++ b/tests/Surfaces/SurfaceTest.php
@@ -13,7 +13,7 @@ use SlackPhp\BlockKit\Tests\TestCase;
  */
 class SurfaceTest extends TestCase
 {
-    public function testCanAddSingleBlocks()
+    public function testCanAddSingleBlocks(): void
     {
         $surface = $this->getMockSurface();
 
@@ -29,7 +29,7 @@ class SurfaceTest extends TestCase
         }
     }
 
-    public function testCanAddVirtualBlocks()
+    public function testCanAddVirtualBlocks(): void
     {
         $surface = $this->getMockSurface();
 
@@ -46,7 +46,7 @@ class SurfaceTest extends TestCase
         }
     }
 
-    public function testCanAddVirtualBlockEarlyOrLateAndBlockCountIsTheSame()
+    public function testCanAddVirtualBlockEarlyOrLateAndBlockCountIsTheSame(): void
     {
         $rows = [
             'a' => '1',
@@ -68,5 +68,10 @@ class SurfaceTest extends TestCase
             ->cols('Foo', 'Bar')
             ->rows($rows);
         $this->assertCount(4, $surface2->getBlocks());
+    }
+
+    public function testCanValidateDupilcateBlockId(): void
+    {
+
     }
 }


### PR DESCRIPTION
# TL;DR
Added duplicate validation for block_id and action_id at  `Surface::class` and `Actions::class` .

# Details
* In the Block Kit, the action id and block id must be unique
* php-slack-block-kit does not have a mechanism to verify if the action id or block id is unique
* I thought that this validation should be done not only on the Slack API side, but also on the library side that generates the json that defines the block