### PR TITLE
Split replace/delete original from response type

### DIFF
--- a/src/Kit.php
+++ b/src/Kit.php
@@ -43,13 +43,13 @@ abstract class Kit
      */
     public static function message(
         Collections\BlockCollection|array|null $blocks = null,
-        ?Surfaces\MessageDirective $directive = null,
+        ?Surfaces\MessageDirective\ResponseType $responseType = null,
         ?string $text = null,
         Collections\AttachmentCollection|array|null $attachments = null,
         ?bool $mrkdwn = null,
         ?string $threadTs = null,
     ): Surfaces\Message {
-        return new Surfaces\Message($blocks, $directive, $text, $attachments, $mrkdwn, $threadTs);
+        return new Surfaces\Message($blocks, $responseType, $text, $attachments, $mrkdwn, $threadTs);
     }
 
     /**

--- a/src/Previewer.php
+++ b/src/Previewer.php
@@ -27,7 +27,9 @@ final class Previewer
         if ($surface instanceof Surfaces\Message) {
             // Block Kit Builder doesn't support message directives or fallback text.
             $surface = (clone $surface)
-                ->directive(null)
+                ->responseType(null)
+                ->deleteOriginal(null)
+                ->replaceOriginal(null)
                 ->text(null)
                 ->mrkdwn(null)
                 ->threadTs(null);

--- a/src/Surfaces/Message.php
+++ b/src/Surfaces/Message.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace SlackPhp\BlockKit\Surfaces;
 
+use SlackPhp\BlockKit\{FauxProperty,
+    Property,
+    Surfaces\MessageDirective\DeleteOriginal,
+    Surfaces\MessageDirective\ReplaceOriginal,
+    Surfaces\MessageDirective\ResponseType};
 use SlackPhp\BlockKit\Blocks\Block;
 use SlackPhp\BlockKit\Collections\{AttachmentCollection, BlockCollection};
-use SlackPhp\BlockKit\{FauxProperty, Property};
 use SlackPhp\BlockKit\Hydration\OmitType;
 use SlackPhp\BlockKit\Validation\{RequiresAnyOf, UniqueIds, ValidCollection, ValidString};
 
@@ -19,8 +23,14 @@ class Message extends Surface
     #[Property, ValidCollection(50, 0), UniqueIds]
     public BlockCollection $blocks;
 
-    #[FauxProperty('response_type', 'replace_original', 'delete_original')]
-    public ?MessageDirective $directive;
+    #[FauxProperty('response_type')]
+    public ?ResponseType $responseType;
+
+    #[FauxProperty('replace_original')]
+    public ?ReplaceOriginal $replaceOriginal;
+
+    #[FauxProperty('delete_original')]
+    public ?DeleteOriginal $deleteOriginal;
 
     #[Property, ValidString]
     public ?string $text;
@@ -40,19 +50,23 @@ class Message extends Surface
      */
     public function __construct(
         BlockCollection|array|null $blocks = null,
-        ?MessageDirective $directive = null,
+        ?ResponseType $directive = null,
         ?string $text = null,
         AttachmentCollection|array|null $attachments = null,
         ?bool $mrkdwn = null,
         ?string $threadTs = null,
         ?bool $ephemeral = null,
+        ?bool $replaceOriginal = null,
+        ?bool $deleteOriginal = null,
     ) {
         parent::__construct($blocks);
         $this->attachments = AttachmentCollection::wrap($attachments);
-        $this->directive($directive ?? ($ephemeral ? MessageDirective::EPHEMERAL : null));
+        $this->responseType($directive ?? ($ephemeral ? ResponseType::EPHEMERAL : null));
         $this->text($text);
         $this->mrkdwn($mrkdwn);
         $this->threadTs($threadTs);
+        $this->replaceOriginal($replaceOriginal);
+        $this->deleteOriginal($deleteOriginal);
     }
 
     /**
@@ -62,7 +76,7 @@ class Message extends Surface
      */
     public function ephemeral(): static
     {
-        return $this->directive(MessageDirective::EPHEMERAL);
+        return $this->responseType(ResponseType::EPHEMERAL);
     }
 
     /**
@@ -70,28 +84,32 @@ class Message extends Surface
      */
     public function inChannel(): static
     {
-        return $this->directive(MessageDirective::IN_CHANNEL);
+        return $this->responseType(ResponseType::IN_CHANNEL);
     }
 
     /**
      * Configures message to "replace_original" mode.
      */
-    public function replaceOriginal(): static
+    public function replaceOriginal(ReplaceOriginal|array|bool|null $replaceOriginal = true): static
     {
-        return $this->directive(MessageDirective::REPLACE_ORIGINAL);
+        $this->replaceOriginal = ReplaceOriginal::fromValue($replaceOriginal);
+
+        return $this;
     }
 
     /**
      * Configures message to "delete_original" mode.
      */
-    public function deleteOriginal(): static
+    public function deleteOriginal(DeleteOriginal|array|bool|null $deleteOriginal = true): static
     {
-        return $this->directive(MessageDirective::DELETE_ORIGINAL);
+        $this->deleteOriginal = DeleteOriginal::fromValue($deleteOriginal);
+
+        return $this;
     }
 
-    public function directive(MessageDirective|array|null $directive): static
+    public function responseType(ResponseType|array|null $responseType): static
     {
-        $this->directive = MessageDirective::fromValue($directive);
+        $this->responseType = ResponseType::fromValue($responseType);
 
         return $this;
     }

--- a/src/Surfaces/MessageDirective/DeleteOriginal.php
+++ b/src/Surfaces/MessageDirective/DeleteOriginal.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Surfaces\MessageDirective;
+
+use SlackPhp\BlockKit\Exception;
+
+enum DeleteOriginal
+{
+    case DELETE_ORIGINAL;
+    case DONT_DELETE_ORIGINAL;
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return match ($this) {
+            self::DELETE_ORIGINAL => ['delete_original' => 'true'],
+            self::DONT_DELETE_ORIGINAL => ['delete_original' => 'false'],
+        };
+    }
+
+    /**
+     * @param self|array<string, string>|bool|null $data
+     * @return static|null
+     */
+    public static function fromValue(self|array|bool|null $data): ?self
+    {
+        if ($data instanceof self) {
+            return $data;
+        }
+
+        if (is_bool($data)) {
+            return $data ? self::DELETE_ORIGINAL : self::DONT_DELETE_ORIGINAL;
+        }
+
+        if (is_array($data)) {
+            $data = array_filter($data);
+            return match ($data) {
+                ['delete_original' => 'true'] => self::DELETE_ORIGINAL,
+                ['delete_original' => 'false'] => self::DONT_DELETE_ORIGINAL,
+                [] => null,
+                default => throw new Exception('Invalid Delete Original enum encountered: %s', [json_encode($data)]),
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Surfaces/MessageDirective/ReplaceOriginal.php
+++ b/src/Surfaces/MessageDirective/ReplaceOriginal.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Surfaces\MessageDirective;
+
+use SlackPhp\BlockKit\Exception;
+
+enum ReplaceOriginal
+{
+    case REPLACE_ORIGINAL;
+    case DONT_REPLACE_ORIGINAL;
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return match ($this) {
+            self::REPLACE_ORIGINAL => ['replace_original' => 'true'],
+            self::DONT_REPLACE_ORIGINAL => ['replace_original' => 'false'],
+        };
+    }
+
+    /**
+     * @param self|array<string, string>|bool|null $data
+     * @return static|null
+     */
+    public static function fromValue(self|array|bool|null $data): ?self
+    {
+        if ($data instanceof self) {
+            return $data;
+        }
+
+        if (is_bool($data)) {
+            return $data ? self::REPLACE_ORIGINAL : self::DONT_REPLACE_ORIGINAL;
+        }
+
+        if (is_array($data)) {
+            $data = array_filter($data);
+            return match ($data) {
+                ['replace_original' => 'true'] => self::REPLACE_ORIGINAL,
+                ['replace_original' => 'false'] => self::DONT_REPLACE_ORIGINAL,
+                [] => null,
+                default => throw new Exception('Invalid Replace Original enum encountered: %s', [json_encode($data)]),
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Surfaces/MessageDirective/ResponseType.php
+++ b/src/Surfaces/MessageDirective/ResponseType.php
@@ -2,16 +2,14 @@
 
 declare(strict_types=1);
 
-namespace SlackPhp\BlockKit\Surfaces;
+namespace SlackPhp\BlockKit\Surfaces\MessageDirective;
 
 use SlackPhp\BlockKit\Exception;
 
-enum MessageDirective
+enum ResponseType
 {
     case EPHEMERAL;
     case IN_CHANNEL;
-    case REPLACE_ORIGINAL;
-    case DELETE_ORIGINAL;
 
     /**
      * @return array<string, string>
@@ -21,8 +19,6 @@ enum MessageDirective
         return match ($this) {
             self::EPHEMERAL => ['response_type' => 'ephemeral'],
             self::IN_CHANNEL => ['response_type' => 'in_channel'],
-            self::REPLACE_ORIGINAL => ['replace_original' => 'true'],
-            self::DELETE_ORIGINAL => ['delete_original' => 'true'],
         };
     }
 
@@ -41,10 +37,8 @@ enum MessageDirective
             return match ($data) {
                 ['response_type' => 'ephemeral'] => self::EPHEMERAL,
                 ['response_type' => 'in_channel'] => self::IN_CHANNEL,
-                ['replace_original' => 'true'] => self::REPLACE_ORIGINAL,
-                ['delete_original' => 'true'] => self::DELETE_ORIGINAL,
                 [] => null,
-                default => throw new Exception('Invalid MessageDirective enum encountered: %s', [json_encode($data)]),
+                default => throw new Exception('Invalid Response Type enum encountered: %s', [json_encode($data)]),
             };
         }
 


### PR DESCRIPTION
Add ability to delete/replace original and change the response type.

This change isn't backwards compatible and should be considered a major change.