### PR TITLE
Fix maxLength

### DIFF
--- a/src/Elements/PlainTextInput.php
+++ b/src/Elements/PlainTextInput.php
@@ -70,7 +70,7 @@ class PlainTextInput extends Input
 
     public function maxLength(?int $maxLength): self
     {
-        $this->maxLength = $maxLength === null ? null : (int) min(1, $maxLength);
+        $this->maxLength = $maxLength === null ? null : (int) max(1, $maxLength);
 
         return $this;
     }


### PR DESCRIPTION
Using `maxLength` would always pick the smallest number of 1 and the given number so max length could never be more than one character.