### PR TITLE
Fix overlooked multiline method

### DIFF
--- a/src/Inputs/TextInput.php
+++ b/src/Inputs/TextInput.php
@@ -150,7 +150,7 @@ class TextInput extends InputElement
         }
 
         if ($data->has('multiline')) {
-            $this->initialValue($data->useValue('multiline'));
+            $this->multiline($data->useValue('multiline'));
         }
 
         if ($data->has('min_length')) {


### PR DESCRIPTION
The multiline property is a boolean, but the hydrate method incorrectly had it using the `initialValue` method, causing a type error.

```
Argument 1 passed to SlackPhp\BlockKit\Inputs\TextInput::initialValue() must be of the type string, bool given, called in /vendor/slack-php/slack-block-kit/src/Inputs/TextInput.php on line 153
```