### PR TITLE
Fix wrong property name for MultiUserSelectMenu initial value

### DIFF
--- a/src/Elements/Selects/MultiUserSelectMenu.php
+++ b/src/Elements/Selects/MultiUserSelectMenu.php
@@ -12,7 +12,7 @@ use SlackPhp\BlockKit\Validation\{RequiresAllOf, ValidCollection};
 class MultiUserSelectMenu extends MultiSelectMenu
 {
     /** @var string[]|null */
-    #[Property('initial_user'), ValidCollection]
+    #[Property('initial_users'), ValidCollection]
     public ?array $initialUsers;
 
     /**


### PR DESCRIPTION
Currently gives following error

```json
{
  "ok": false,
  "error": "invalid_arguments",
  "warning": "missing_charset",
  "response_metadata": {
    "messages": [
      "[ERROR] failed to match all allowed schemas [json-pointer:\/view]",
      "[ERROR] invalid additional property: initial_user [json-pointer:\/view\/blocks\/1\/element]"
    ],
    "warnings": [
      "missing_charset"
    ]
  }
}
```

This is because correct property name for `multi_users_select` is `initial_users` instead of `initial_user`