### PR TITLE
make properties explicitly nullable

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -14,7 +14,7 @@ class Exception extends RuntimeException
     /**
      * @param array<string|int> $args
      */
-    public function __construct(string $message, array $args = [], Throwable $previous = null)
+    public function __construct(string $message, array $args = [], ?Throwable $previous = null)
     {
         $message = $args ? vsprintf($message, $args) : $message;
 

--- a/src/Hydration/HydrationException.php
+++ b/src/Hydration/HydrationException.php
@@ -12,7 +12,7 @@ class HydrationException extends Exception
     /**
      * @param array<string|int> $args
      */
-    public function __construct(string $message, array $args = [], Throwable $previous = null)
+    public function __construct(string $message, array $args = [], ?Throwable $previous = null)
     {
         parent::__construct("FromArray Error: {$message}", $args, $previous);
     }

--- a/src/Kit.php
+++ b/src/Kit.php
@@ -120,7 +120,7 @@ abstract class Kit
     }
 
     public static function file(
-        string $externalId = null,
+        ?string $externalId = null,
         ?string $source = 'remote',
         ?string $blockId = null,
     ): Blocks\File {


### PR DESCRIPTION
I recently upgraded to PHP v8.4.5 and got an error when trying to post msgs using `chatPostMessage()`.

Error message was:
`SlackPhp\\BlockKit\\Kit::file(): Implicitly marking parameter $externalId as nullable is deprecated, the explicit nullable type must be used instead`

I think the fix is to change line 123 in Kit.php from:
`string $externalId = null,`

to:
`?string $externalId = null,`

I realize this may only be one of many issues related to PHP v4.4 compatibility, but this is the one that I ran into.